### PR TITLE
Use GitHub releases api instead of updater

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -32,11 +32,11 @@ const download = async (url, path) => {
 };
 
 const getLatestVersion = async () => {
-  const endpoint = 'https://updater.dvc.org';
+  const endpoint = 'https://api.github.com/repos/iterative/dvc/releases/latest';
   const response = await fetch(endpoint, { method: 'GET' });
-  const { version } = await response.json();
+  const { tag_name } = await response.json();
 
-  return version;
+  return tag_name;
 };
 
 const setupDVC = async opts => {


### PR DESCRIPTION
`updater` lambda is broken per https://github.com/appleboy/lambda-action/issues/46 

See failure:

https://github.com/iterative/lambda-latest-version/runs/6061113502?check_suite_focus=true#step:8:17