### PR TITLE
drop ubuntu 18.04 from tests

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,6 @@ jobs:
           - '1.0.1'
           - '2.18.1'
     runs-on: ${{ matrix.system }}
-    container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,21 +25,10 @@ jobs:
         version:
           - '1.0.1'
           - '2.18.1'
-        include:
-          - system: ubuntu-18.04
-            container: ubuntu:18.04
-            version: '1.0.1'
-          - system: ubuntu-18.04
-            container: ubuntu:18.04
-            version: '2.18.1'
     runs-on: ${{ matrix.system }}
     container: ${{ matrix.container }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        if: matrix.container == 'ubuntu:18.04'
-        with:
-          node-version: '16'
       - uses: actions/setup-python@v3
         if: matrix.system == 'windows'
         with:


### PR DESCRIPTION
 No longer worth testing this, I think:
 - [deprecated](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/)  
 - jobs stuck pending forever it [seems](https://github.com/iterative/setup-dvc/actions/runs/4876668842/jobs/8700438527?pr=49)